### PR TITLE
Add Markdown support to RichTextEditor

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "@tiptap/extension-link": "^3.22.4",
     "@tiptap/extension-placeholder": "^3.22.4",
     "@tiptap/extension-underline": "^3.22.4",
+    "@tiptap/markdown": "^3.22.4",
     "@tiptap/pm": "^3.22.4",
     "@tiptap/react": "^3.22.4",
     "@tiptap/starter-kit": "^3.22.4",
@@ -51,7 +52,8 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^3.4.18",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "tiptap-markdown": "^0.9.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@tiptap/extension-underline':
         specifier: ^3.22.4
         version: 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))
+      '@tiptap/markdown':
+        specifier: ^3.22.4
+        version: 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)
       '@tiptap/pm':
         specifier: ^3.22.4
         version: 3.22.4
@@ -113,6 +116,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.18)
+      tiptap-markdown:
+        specifier: ^0.9.0
+        version: 0.9.0(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
@@ -1313,6 +1319,12 @@ packages:
       '@tiptap/core': 3.22.4
       '@tiptap/pm': 3.22.4
 
+  '@tiptap/markdown@3.22.4':
+    resolution: {integrity: sha512-gcoLOq5TBntw13QdeWMy7yc2X+b9yTplcFb5kpMQNgNoxlu0+jlX4LiBR+E6lOV+m+AtkprHHltTYyKG23bdOw==}
+    peerDependencies:
+      '@tiptap/core': 3.22.4
+      '@tiptap/pm': 3.22.4
+
   '@tiptap/pm@3.22.4':
     resolution: {integrity: sha512-hj8Qka6WcHRllHUdeSjDnq2XaisUo4KsoGJc1WcFpoa1Yd+OeD861zUMnV7DFVGdZRy45Obht0CUYJpXQ4yA4w==}
 
@@ -1378,11 +1390,29 @@ packages:
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
 
+  '@types/linkify-it@3.0.5':
+    resolution: {integrity: sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==}
+
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
   '@types/mapbox__point-geometry@0.1.4':
     resolution: {integrity: sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==}
 
+  '@types/markdown-it@13.0.9':
+    resolution: {integrity: sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@1.0.5':
+    resolution: {integrity: sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -1791,6 +1821,10 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
@@ -2125,6 +2159,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkify-it@5.0.1:
+    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+
   linkifyjs@4.3.2:
     resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
 
@@ -2187,6 +2224,18 @@ packages:
     resolution: {integrity: sha512-YxW9glb/YrDXGDhqy1u+aG113+L86ttAUpTd6sCkGHyUKMXOX8qbGHJQVqxOczy+4CtRKnqcCfSura2MzB0nQA==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
+  markdown-it-task-lists@2.1.1:
+    resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
+
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
+    hasBin: true
+
+  marked@17.0.6:
+    resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   martinez-polygon-clipping@0.7.4:
     resolution: {integrity: sha512-jBEwrKtA0jTagUZj2bnmb4Yg2s4KnJGRePStgI7bAVjtcipKiF39R4LZ2V/UT61jMYWrTcBhPazexeqd6JAVtw==}
 
@@ -2217,6 +2266,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2570,6 +2622,9 @@ packages:
   prosemirror-keymap@1.2.3:
     resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
 
+  prosemirror-markdown@1.13.4:
+    resolution: {integrity: sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==}
+
   prosemirror-model@1.25.4:
     resolution: {integrity: sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==}
 
@@ -2593,6 +2648,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2877,6 +2936,11 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  tiptap-markdown@0.9.0:
+    resolution: {integrity: sha512-dKLQ9iiuGNgrlGVjrNauF/UBzWu4LYOx5pkD0jNkmQt/GOwfCJsBuzZTsf1jZ204ANHOm572mZ9PYvGh1S7tpQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.0.1
+
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
@@ -2921,6 +2985,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -4330,6 +4397,12 @@ snapshots:
       '@tiptap/core': 3.22.4(@tiptap/pm@3.22.4)
       '@tiptap/pm': 3.22.4
 
+  '@tiptap/markdown@3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)':
+    dependencies:
+      '@tiptap/core': 3.22.4(@tiptap/pm@3.22.4)
+      '@tiptap/pm': 3.22.4
+      marked: 17.0.6
+
   '@tiptap/pm@3.22.4':
     dependencies:
       prosemirror-changeset: 2.4.1
@@ -4447,11 +4520,29 @@ snapshots:
       '@types/ms': 2.1.0
       '@types/node': 24.9.1
 
+  '@types/linkify-it@3.0.5': {}
+
+  '@types/linkify-it@5.0.0': {}
+
   '@types/mapbox__point-geometry@0.1.4': {}
+
+  '@types/markdown-it@13.0.9':
+    dependencies:
+      '@types/linkify-it': 3.0.5
+      '@types/mdurl': 1.0.5
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
 
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/mdurl@1.0.5': {}
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/ms@2.1.0': {}
 
@@ -4814,6 +4905,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  entities@4.5.0: {}
 
   entities@6.0.1: {}
 
@@ -5191,6 +5284,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkify-it@5.0.1:
+    dependencies:
+      uc.micro: 2.1.0
+
   linkifyjs@4.3.2: {}
 
   lit-element@4.2.1:
@@ -5296,6 +5393,19 @@ snapshots:
       supercluster: 8.0.1
       tinyqueue: 3.0.0
 
+  markdown-it-task-lists@2.1.1: {}
+
+  markdown-it@14.2.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.1
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  marked@17.0.6: {}
+
   martinez-polygon-clipping@0.7.4:
     dependencies:
       robust-predicates: 2.0.4
@@ -5392,6 +5502,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdurl@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -5739,6 +5851,12 @@ snapshots:
       prosemirror-state: 1.4.4
       w3c-keyname: 2.2.8
 
+  prosemirror-markdown@1.13.4:
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.2.0
+      prosemirror-model: 1.25.4
+
   prosemirror-model@1.25.4:
     dependencies:
       orderedmap: 2.1.1
@@ -5776,6 +5894,8 @@ snapshots:
   protocol-buffers-schema@3.6.0: {}
 
   proxy-from-env@1.1.0: {}
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -6093,6 +6213,14 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  tiptap-markdown@0.9.0(@tiptap/core@3.22.4(@tiptap/pm@3.22.4)):
+    dependencies:
+      '@tiptap/core': 3.22.4(@tiptap/pm@3.22.4)
+      '@types/markdown-it': 13.0.9
+      markdown-it: 14.2.0
+      markdown-it-task-lists: 2.1.1
+      prosemirror-markdown: 1.13.4
+
   tldts-core@6.1.86: {}
 
   tldts@6.1.86:
@@ -6124,6 +6252,8 @@ snapshots:
   typescript@5.2.2: {}
 
   typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
 
   undici-types@7.16.0: {}
 

--- a/frontend/src/components/shared/RichTextEditor.tsx
+++ b/frontend/src/components/shared/RichTextEditor.tsx
@@ -1,110 +1,85 @@
-import DOMPurify, { type Config as DOMPurifyConfig } from "dompurify";
-import Link from "@tiptap/extension-link";
-import Placeholder from "@tiptap/extension-placeholder";
-import Underline from "@tiptap/extension-underline";
-import { EditorContent, useEditor } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
+import Link from '@tiptap/extension-link'
+import Placeholder from '@tiptap/extension-placeholder'
+import Underline from '@tiptap/extension-underline'
+import { Markdown } from '@tiptap/markdown'
+import { EditorContent, useEditor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import DOMPurify, { type Config as DOMPurifyConfig } from 'dompurify'
+import ReactMarkdown from 'react-markdown'
 
 // ─── Shared sanitizer ────────────────────────────────────────────────────────
 
 const PURIFY_CONFIG: DOMPurifyConfig = {
-  ALLOWED_TAGS: [
-    "p",
-    "h3",
-    "h4",
-    "h5",
-    "strong",
-    "em",
-    "u",
-    "ul",
-    "ol",
-    "li",
-    "br",
-    "a",
-  ],
-  ALLOWED_ATTR: ["href"],
+  ALLOWED_TAGS: ['p', 'h1', 'h2', 'h3', 'strong', 'em', 'u', 'ul', 'ol', 'li', 'br', 'a'],
+  ALLOWED_ATTR: ['href'],
   FORCE_BODY: true,
-};
+}
 
 /** Sanitize RTE HTML to the allowed tag/attribute allowlist. */
 export function sanitizeRteHtml(html: string): string {
-  return DOMPurify.sanitize(html, PURIFY_CONFIG);
+  return DOMPurify.sanitize(html, PURIFY_CONFIG)
 }
 
 // ─── Display component ────────────────────────────────────────────────────────
 
 interface RichTextContentProps {
-  html: string;
-  className?: string;
+  content: string
+  className?: string
 }
 
-export function RichTextContent({
-  html,
-  className = "",
-}: RichTextContentProps) {
-  const safe = sanitizeRteHtml(html);
+export function RichTextContent({ content, className = '' }: RichTextContentProps) {
   return (
-    <div
-      className={`rte-editor ${className}`}
-      dangerouslySetInnerHTML={{ __html: safe }}
-    />
-  );
+    <div className={`rte-editor ${className}`}>
+      <ReactMarkdown>{content}</ReactMarkdown>
+    </div>
+  )
 }
 
-const MAX_CHARS = 10_000;
+const MAX_CHARS = 10_000
 
 // ─── Toolbar button ──────────────────────────────────────────────────────────
 
 interface ToolbarButtonProps {
-  onClick: () => void;
-  isActive?: boolean;
-  title: string;
-  children: React.ReactNode;
+  onClick: () => void
+  isActive?: boolean
+  title: string
+  children: React.ReactNode
 }
 
-function ToolbarButton({
-  onClick,
-  isActive,
-  title,
-  children,
-}: ToolbarButtonProps) {
+function ToolbarButton({ onClick, isActive, title, children }: ToolbarButtonProps) {
   return (
     <button
       type="button"
       onClick={onClick}
       title={title}
       className={`w-7 h-7 flex items-center justify-center rounded text-sm transition-colors ${
-        isActive
-          ? "bg-hot-red-100 text-hot-red-600"
-          : "text-hot-gray-600 hover:bg-hot-gray-100"
+        isActive ? 'bg-hot-red-100 text-hot-red-600' : 'text-hot-gray-600 hover:bg-hot-gray-100'
       }`}
     >
       {children}
     </button>
-  );
+  )
 }
 
 // ─── Editor component ─────────────────────────────────────────────────────────
 
 interface RichTextEditorProps {
-  id?: string;
-  value: string;
-  onChange: (html: string) => void;
-  placeholder?: string;
+  id?: string
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
 }
 
 function RichTextEditor({
   id,
   value,
   onChange,
-  placeholder = "Write something…",
+  placeholder = 'Write something…',
 }: RichTextEditorProps) {
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
-        // Lock headings to h3/h4/h5 only; h1/h2/h6 are stripped on parse/paste.
-        heading: { levels: [3, 4, 5] },
-        // Disable elements outside the allowed set.
+        heading: { levels: [1, 2, 3] },
         blockquote: false,
         code: false,
         codeBlock: false,
@@ -115,52 +90,54 @@ function RichTextEditor({
       Placeholder.configure({ placeholder }),
       Link.configure({
         openOnClick: false,
-        // Force safe link attributes so stored HTML never opens without referrer protection.
-        HTMLAttributes: { rel: "noopener noreferrer", target: "_blank" },
-        // Block non-http(s) schemes (javascript:, data:, etc.) at the extension level.
+        HTMLAttributes: { rel: 'noopener noreferrer', target: '_blank' },
         validate: (href) => /^https?:\/\//i.test(href),
+      }),
+      Markdown.configure({
+        markedOptions: { gfm: true },
       }),
     ],
     editorProps: {
       attributes: {
         ...(id ? { id } : {}),
-        class: "outline-none",
+        class: 'outline-none',
       },
-      // Sanitize HTML on paste before ProseMirror parses it.
       transformPastedHTML(html: string) {
-        return sanitizeRteHtml(html);
+        return sanitizeRteHtml(html)
       },
     },
+    // Tells the Markdown extension to parse the initial content as Markdown
+    // so saved Markdown strings round-trip correctly on reload.
+    contentType: 'markdown' as const,
     content: value,
     onUpdate({ editor }) {
       if (editor.isEmpty) {
-        onChange("");
-        return;
+        onChange('')
+        return
       }
-      // Enforce plain-text length cap to prevent oversized payloads.
-      if (editor.getText().length > MAX_CHARS) return;
-      onChange(sanitizeRteHtml(editor.getHTML()));
+      if (editor.getText().length > MAX_CHARS) return
+      onChange(editor.getMarkdown())
     },
-  });
+  })
 
-  if (!editor) return null;
+  if (!editor) return null
 
   const run = (fn: (c: ReturnType<typeof editor.chain>) => unknown) => () =>
-    fn(editor.chain().focus());
+    fn(editor.chain().focus())
 
   function handleLinkToggle() {
-    if (editor.isActive("link")) {
-      editor.chain().focus().unsetLink().run();
-      return;
+    if (editor.isActive('link')) {
+      editor.chain().focus().unsetLink().run()
+      return
     }
-    const url = window.prompt("URL");
-    if (!url) return;
-    const href = url.startsWith("http") ? url : `https://${url}`;
-    editor.chain().focus().setLink({ href }).run();
+    const url = window.prompt('URL')
+    if (!url) return
+    const href = url.startsWith('http') ? url : `https://${url}`
+    editor.chain().focus().setLink({ href }).run()
   }
 
-  const charCount = editor.getText().length;
-  const nearLimit = charCount > MAX_CHARS * 0.9;
+  const charCount = editor.getText().length
+  const nearLimit = charCount > MAX_CHARS * 0.9
 
   return (
     <>
@@ -168,45 +145,45 @@ function RichTextEditor({
         <div className="flex flex-wrap gap-xs p-xs border-b border-hot-gray-200 bg-hot-gray-50">
           <ToolbarButton
             onClick={run((c) => c.toggleBold().run())}
-            isActive={editor.isActive("bold")}
+            isActive={editor.isActive('bold')}
             title="Bold"
           >
             <strong>B</strong>
           </ToolbarButton>
           <ToolbarButton
             onClick={run((c) => c.toggleItalic().run())}
-            isActive={editor.isActive("italic")}
+            isActive={editor.isActive('italic')}
             title="Italic"
           >
             <em>I</em>
           </ToolbarButton>
           <ToolbarButton
             onClick={run((c) => c.toggleUnderline().run())}
-            isActive={editor.isActive("underline")}
+            isActive={editor.isActive('underline')}
             title="Underline"
           >
-            <span style={{ textDecoration: "underline" }}>U</span>
+            <span style={{ textDecoration: 'underline' }}>U</span>
           </ToolbarButton>
 
           <div className="w-px bg-hot-gray-200 mx-xs self-stretch" />
 
           <ToolbarButton
-            onClick={run((c) => c.toggleHeading({ level: 3 }).run())}
-            isActive={editor.isActive("heading", { level: 3 })}
+            onClick={run((c) => c.toggleHeading({ level: 1 }).run())}
+            isActive={editor.isActive('heading', { level: 1 })}
             title="Heading 1"
           >
             <span className="font-bold text-xs">H1</span>
           </ToolbarButton>
           <ToolbarButton
-            onClick={run((c) => c.toggleHeading({ level: 4 }).run())}
-            isActive={editor.isActive("heading", { level: 4 })}
+            onClick={run((c) => c.toggleHeading({ level: 2 }).run())}
+            isActive={editor.isActive('heading', { level: 2 })}
             title="Heading 2"
           >
             <span className="font-bold text-xs">H2</span>
           </ToolbarButton>
           <ToolbarButton
-            onClick={run((c) => c.toggleHeading({ level: 5 }).run())}
-            isActive={editor.isActive("heading", { level: 5 })}
+            onClick={run((c) => c.toggleHeading({ level: 3 }).run())}
+            isActive={editor.isActive('heading', { level: 3 })}
             title="Heading 3"
           >
             <span className="font-bold text-xs">H3</span>
@@ -216,16 +193,10 @@ function RichTextEditor({
 
           <ToolbarButton
             onClick={run((c) => c.toggleBulletList().run())}
-            isActive={editor.isActive("bulletList")}
+            isActive={editor.isActive('bulletList')}
             title="Bullet list"
           >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 16 16"
-              fill="currentColor"
-              aria-hidden="true"
-            >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
               <circle cx="2" cy="3.5" r="1.5" />
               <rect x="5" y="2.5" width="10" height="2" rx="1" />
               <circle cx="2" cy="8" r="1.5" />
@@ -236,16 +207,10 @@ function RichTextEditor({
           </ToolbarButton>
           <ToolbarButton
             onClick={run((c) => c.toggleOrderedList().run())}
-            isActive={editor.isActive("orderedList")}
+            isActive={editor.isActive('orderedList')}
             title="Ordered list"
           >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 16 16"
-              fill="currentColor"
-              aria-hidden="true"
-            >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
               <text x="0" y="5" fontSize="6" fontFamily="monospace">
                 1.
               </text>
@@ -265,38 +230,27 @@ function RichTextEditor({
 
           <ToolbarButton
             onClick={handleLinkToggle}
-            isActive={editor.isActive("link")}
-            title={editor.isActive("link") ? "Remove link" : "Add link"}
+            isActive={editor.isActive('link')}
+            title={editor.isActive('link') ? 'Remove link' : 'Add link'}
           >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 16 16"
-              fill="currentColor"
-              aria-hidden="true"
-            >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
               <path d="M6.4 9.6a3.2 3.2 0 0 0 4.53.01l1.6-1.6a3.2 3.2 0 0 0-4.52-4.52L7.1 4.4a.8.8 0 1 0 1.13 1.13l.91-.91a1.6 1.6 0 0 1 2.26 2.26l-1.6 1.6a1.6 1.6 0 0 1-2.27 0 .8.8 0 0 0-1.13 1.13Z" />
               <path d="M9.6 6.4a3.2 3.2 0 0 0-4.53-.01l-1.6 1.6a3.2 3.2 0 0 0 4.52 4.52l.91-.91a.8.8 0 1 0-1.13-1.13l-.91.91a1.6 1.6 0 0 1-2.26-2.26l1.6-1.6a1.6 1.6 0 0 1 2.27 0 .8.8 0 0 0 1.13-1.13Z" />
             </svg>
           </ToolbarButton>
 
           <div className="ml-auto flex items-center pr-xs">
-            <span
-              className={`text-xs ${nearLimit ? "text-hot-red-500" : "text-hot-gray-400"}`}
-            >
+            <span className={`text-xs ${nearLimit ? 'text-hot-red-500' : 'text-hot-gray-400'}`}>
               {charCount}/{MAX_CHARS}
             </span>
           </div>
         </div>
         <div className="rte-editor">
-          <EditorContent
-            editor={editor}
-            className="px-md py-sm text-base min-h-[5rem]"
-          />
+          <EditorContent editor={editor} className="px-md py-sm text-base min-h-[5rem]" />
         </div>
       </div>
     </>
-  );
+  )
 }
 
-export default RichTextEditor;
+export default RichTextEditor

--- a/frontend/src/portal-plans/MyPlanPage.tsx
+++ b/frontend/src/portal-plans/MyPlanPage.tsx
@@ -395,7 +395,7 @@ function MyPlanPage() {
               </Tag>
             )}
             {plan!.description && (
-              <RichTextContent html={plan!.description} className="py-md" />
+              <RichTextContent content={plan!.description ?? ""} className="py-md" />
             )}
             {plan!.images.length > 0 && (
               <Carousel

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -118,3 +118,21 @@ hotosm-tool-menu {
   overflow-wrap: break-word;
   word-break: break-word;
 }
+
+.rte-editor ul,
+.rte-editor ol {
+  padding-left: 1.5rem;
+  margin: 0.5rem 0;
+}
+
+.rte-editor ul {
+  list-style-type: disc;
+}
+
+.rte-editor ol {
+  list-style-type: decimal;
+}
+
+.rte-editor li {
+  margin: 0.25rem 0;
+}


### PR DESCRIPTION
Adds Markdown support to the shared RichTextEditor component. 
Integrates the TipTap Markdown extension and switches display rendering to react-markdown, so editor content is now stored and rendered as Markdown instead of raw HTML. 
RichTextContent now takes a content (Markdown) prop, and the sanitizer allowlist is updated accordingly.