### PR TITLE
Fix: launch the project with make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ CLAUDE.md
 .env.local
 .env.*.local
 
+# Local dev HTTPS certs (mkcert)
+/certs/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,60 @@
+{
+	auto_https off
+	admin off
+}
+
+http://portal.hotosm.test, http://login.hotosm.test {
+	redir https://{host}{uri} permanent
+}
+
+portal.hotosm.test {
+	tls /etc/caddy/certs/dev.crt /etc/caddy/certs/dev.key
+
+	@api path /api/*
+	handle @api {
+		reverse_proxy backend-dev:8000
+	}
+
+	handle {
+		reverse_proxy frontend-dev:5173
+	}
+}
+
+login.hotosm.test {
+	tls /etc/caddy/certs/dev.crt /etc/caddy/certs/dev.key
+
+	@wellknown path /.well-known/*
+	handle @wellknown {
+		reverse_proxy hanko:8000
+	}
+
+	@loginPost {
+		path /login
+		method POST
+	}
+	handle @loginPost {
+		reverse_proxy hanko:8000
+	}
+
+	@me path /me
+	handle @me {
+		reverse_proxy login-backend:8000
+	}
+
+	@backendApi path /api/*
+	handle @backendApi {
+		reverse_proxy login-backend:8000
+	}
+
+	@hankoApi path /registration/* /logout/* /sessions/* /users/* /passcode/* /webauthn/* /token/* /thirdparty/* /profile/* /emails/* /password/* /flow/*
+	handle @hankoApi {
+		reverse_proxy hanko:8000
+	}
+
+	@root path /
+	redir @root /app permanent
+
+	handle {
+		reverse_proxy login-frontend:5174
+	}
+}

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-.PHONY: help install dev dev-standalone dev-docker stop test test-backend test-frontend lint lint-fix clean build deploy-test
+.PHONY: help install dev dev-standalone dev-docker certs stop test test-backend test-frontend lint lint-fix clean build deploy-test
 
 UV_LOCAL_ENV ?= .venv-local
 UV_LOCAL = UV_PROJECT_ENVIRONMENT=$(UV_LOCAL_ENV) uv
 
-HOT_DEV_ENV := ../hot-dev-env
 LOGIN_DIR := ../login
+CERTS_DIR := certs
+DEV_DOMAINS := portal.hotosm.test login.hotosm.test
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'
@@ -30,27 +31,24 @@ dev-frontend: ## Run frontend locally (without Docker)
 	cd frontend && pnpm dev
 
 # Development (Docker)
-dev: ## Run full dev environment: delegates to hot-dev-env (Traefik, https://portal.hotosm.test) if present, else standalone. Also brings up Login if ../login is present.
-	@if [ -f "$(HOT_DEV_ENV)/Makefile" ]; then \
-		if [ -d "$(LOGIN_DIR)/frontend" ] && [ -d "$(LOGIN_DIR)/backend" ]; then \
-			if docker ps --filter "name=^/hotosm-portal-frontend$$" --filter "status=running" -q | grep -q . && \
-			   docker ps --filter "name=^/hotosm-login-frontend$$" --filter "status=running" -q | grep -q .; then \
-				echo "hot-dev-env is already running Portal + Login — nothing to do."; \
-			else \
-				echo "hot-dev-env + login detected — starting Portal and Login together (https://portal.hotosm.test, https://login.hotosm.test)"; \
-				docker compose -f "$(HOT_DEV_ENV)/docker-compose.yml" --project-directory "$(HOT_DEV_ENV)" up portal-frontend portal-backend portal-db login-frontend login-backend hanko hanko-db mailhog traefik --build; \
-			fi \
-		else \
-			if docker ps --filter "name=^/hotosm-portal-frontend$$" --filter "status=running" -q | grep -q .; then \
-				echo "hot-dev-env is already running Portal at https://portal.hotosm.test — nothing to do."; \
-			else \
-				echo "hot-dev-env detected at $(HOT_DEV_ENV) — delegating to 'make dev-portal' (https://portal.hotosm.test)"; \
-				$(MAKE) -C $(HOT_DEV_ENV) dev-portal; \
-			fi \
-		fi \
-	else \
-		$(MAKE) dev-standalone; \
+certs: ## Generate local HTTPS certs for *.hotosm.test via mkcert (used by Caddy, no Traefik)
+	@command -v mkcert >/dev/null 2>&1 || { echo "Error: mkcert is required. Install it from https://github.com/FiloSottile/mkcert and re-run 'make certs'." >&2; exit 1; }
+	@mkdir -p $(CERTS_DIR)
+	@if [ ! -f "$(CERTS_DIR)/dev.crt" ] || [ ! -f "$(CERTS_DIR)/dev.key" ]; then \
+		mkcert -install; \
+		mkcert -cert-file $(CERTS_DIR)/dev.crt -key-file $(CERTS_DIR)/dev.key $(DEV_DOMAINS); \
 	fi
+
+dev: certs ## Run Portal + Login standalone with HTTPS via Caddy (no hot-dev-env, no Traefik) at https://portal.hotosm.test. Requires ../login to be present.
+	@if [ ! -d "$(LOGIN_DIR)/frontend" ] || [ ! -d "$(LOGIN_DIR)/backend" ]; then \
+		echo "Error: The login repository must be in the same folder to run the project and access it through the login." >&2; \
+		exit 1; \
+	fi
+	@echo "Starting Portal + Login standalone with HTTPS (Caddy, no hot-dev-env, no Traefik)."
+	@echo "Portal: https://portal.hotosm.test"
+	@echo "Login:  https://login.hotosm.test"
+	@echo "Make sure both hosts resolve to 127.0.0.1 in your hosts file."
+	docker compose --profile dev up --build
 
 dev-standalone: ## Run Portal only, without Traefik (http://localhost:5173)
 	@echo "Starting standalone development environment..."

--- a/config/hanko-config.yaml
+++ b/config/hanko-config.yaml
@@ -1,0 +1,90 @@
+server:
+  public:
+    address: ":8000"
+    cors:
+      allow_origins:
+        - "https://portal.hotosm.test"
+        - "https://login.hotosm.test"
+      allow_credentials: true
+      unsafe_wildcard_origin_allowed: true
+
+database:
+  database: hanko
+  user: hanko
+  password: hanko
+  host: hanko-db
+  port: 5432
+
+secrets:
+  keys:
+    - "abcdefghijklmnopqrstuvwxyz123456"
+
+service:
+  name: "HOTOSM Portal (Dev)"
+
+account:
+  allow_deletion: true
+
+passkey:
+  enabled: false
+  acquire_on_login: never
+  acquire_on_registration: never
+
+mfa:
+  security_keys:
+    enabled: false
+
+webauthn:
+  enabled: false
+  relying_party:
+    id: "hotosm.test"
+    display_name: "HOTOSM Portal"
+    origins:
+      - "https://portal.hotosm.test"
+      - "https://login.hotosm.test"
+
+email:
+  require_verification: true
+  use_for_authentication: false
+
+passcode:
+  enabled: false
+  ttl: 300
+
+password:
+  enabled: true
+  min_length: 8
+  recovery: true
+
+email_delivery:
+  enabled: true
+  smtp:
+    host: "mailhog"
+    port: 1025
+  from_address: "noreply@hotosm.test"
+  from_name: "HOTOSM (Dev)"
+
+session:
+  lifespan: 1h
+  issuer: "https://login.hotosm.test"
+  audience:
+    - "https://portal.hotosm.test"
+    - "https://login.hotosm.test"
+  cookie:
+    name: "hanko"
+    domain: ".hotosm.test"
+    http_only: true
+    same_site: none
+    secure: true
+
+third_party:
+  redirect_url: "https://login.hotosm.test/app/thirdparty/callback"
+  error_redirect_url: "https://login.hotosm.test/app/error"
+  allowed_redirect_urls:
+    - "https://portal.hotosm.test/**"
+    - "https://login.hotosm.test/**"
+  cookie:
+    domain: ".hotosm.test"
+    http_only: true
+    same_site: none
+    secure: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,11 +87,15 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-portal}:${POSTGRES_PASSWORD:-portal}@db:5432/${POSTGRES_DB:-portal}
       DEBUG: "true"
-      # Authentication settings (expects login service to be running)
-      HANKO_API_URL: ${HANKO_API_URL:-https://login.hotosm.test}
-      JWT_ISSUER: ${JWT_ISSUER:-https://login.hotosm.test}
+      # Authentication settings (talks to the local hanko/login-dev services below).
+      # Fixed (not overridable via .env): JWT_ISSUER must match hanko-config.yaml's
+      # session.issuer (the public login.hotosm.test origin), NOT the internal
+      # HANKO_API_URL — otherwise "auto" would resolve the issuer to http://hanko:8000
+      # and token validation would fail.
+      HANKO_API_URL: http://hanko:8000
+      JWT_ISSUER: https://login.hotosm.test
       COOKIE_SECRET: ${COOKIE_SECRET}
-      COOKIE_DOMAIN: ${COOKIE_DOMAIN:-}
+      COOKIE_DOMAIN: ${COOKIE_DOMAIN:-.hotosm.test}
       COOKIE_SECURE: ${COOKIE_SECURE:-true}
       OSM_CLIENT_ID: ${OSM_CLIENT_ID:-}
       OSM_CLIENT_SECRET: ${OSM_CLIENT_SECRET:-}
@@ -113,6 +117,8 @@ services:
         condition: service_healthy
       minio:
         condition: service_healthy
+      hanko:
+        condition: service_started
     command: sh -c "uv run alembic upgrade head && uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload --reload-dir app --reload-exclude '.venv/*' --reload-exclude 'app/tests/*' --reload-exclude '.pytest_cache/*'"
     profiles:
       - dev
@@ -186,7 +192,8 @@ services:
       target: development
     container_name: portal-frontend-dev
     environment:
-      - VITE_API_URL=http://localhost:8000
+      - VITE_HANKO_URL=https://login.hotosm.test
+      - VITE_API_URL=https://portal.hotosm.test/api
       - VITE_BACKEND_URL=http://backend-dev:8000
     ports:
       - "${FRONTEND_PORT:-5173}:5173"
@@ -198,8 +205,137 @@ services:
     profiles:
       - dev
 
+  # Caddy reverse proxy: terminates HTTPS for portal.hotosm.test / login.hotosm.test
+  # locally, without Traefik or hot-dev-env.
+  caddy:
+    image: caddy:2-alpine
+    container_name: portal-caddy
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./certs:/etc/caddy/certs:ro
+    ports:
+      - "80:80"
+      - "443:443"
+    depends_on:
+      - frontend-dev
+      - backend-dev
+      - login-frontend
+      - login-backend
+      - hanko
+    profiles:
+      - dev
+
+  # --- Login / Hanko (built from the sibling ../login repo) ---
+
+  login-frontend:
+    build:
+      context: ../login/frontend
+      dockerfile: Dockerfile
+      target: dev
+    container_name: portal-login-frontend
+    volumes:
+      - ../login/frontend/src:/app/src
+      - ../login/frontend/public:/app/public
+      - ../login/frontend/vite.config.ts:/app/vite.config.ts
+    environment:
+      - VITE_HANKO_URL=https://login.hotosm.test
+      - VITE_BACKEND_URL=https://login.hotosm.test/api
+    depends_on:
+      - login-backend
+    profiles:
+      - dev
+
+  login-backend:
+    build:
+      context: ../login/backend
+      dockerfile: Dockerfile
+      target: dev
+    container_name: portal-login-backend
+    volumes:
+      - ../login/backend/app:/app/app
+    environment:
+      - HANKO_API_URL=http://hanko:8000
+      - JWT_ISSUER=https://login.hotosm.test
+      - COOKIE_SECRET=${COOKIE_SECRET}
+      - OSM_CLIENT_ID=${OSM_CLIENT_ID:-}
+      - OSM_CLIENT_SECRET=${OSM_CLIENT_SECRET:-}
+      # Fixed (not the portal OSM_REDIRECT_URI): this is login-backend's own callback,
+      # must be registered as an additional redirect URI on the same OSM OAuth app.
+      - OSM_REDIRECT_URI=https://login.hotosm.test/api/auth/osm/callback
+      - ADMIN_EMAILS=${ADMIN_EMAILS:-admin@hotosm.org}
+      - PORTAL_BACKEND_URL=http://backend-dev:8000
+    depends_on:
+      - hanko
+      - hanko-db
+    profiles:
+      - dev
+
+  hanko-migrate:
+    image: ghcr.io/teamhanko/hanko:v2.5.0
+    container_name: portal-hanko-migrate
+    volumes:
+      - ./config/hanko-config.yaml:/etc/config/config.yaml:ro
+    command: migrate up --config /etc/config/config.yaml
+    environment:
+      - DATABASE_URL=postgres://hanko:hanko@hanko-db:5432/hanko?sslmode=disable
+    depends_on:
+      hanko-db:
+        condition: service_healthy
+    restart: "no"
+    profiles:
+      - dev
+
+  hanko:
+    image: ghcr.io/teamhanko/hanko:v2.5.0
+    container_name: portal-hanko
+    volumes:
+      - ./config/hanko-config.yaml:/etc/config/config.yaml:ro
+    command: serve --config /etc/config/config.yaml public
+    environment:
+      - DATABASE_URL=postgres://hanko:hanko@hanko-db:5432/hanko?sslmode=disable
+      - SESSION_COOKIE_DOMAIN=.hotosm.test
+      - SESSION_COOKIE_HTTP_ONLY=true
+      - SESSION_COOKIE_SAME_SITE=none
+      - SESSION_COOKIE_SECURE=true
+      - THIRD_PARTY_COOKIE_DOMAIN=.hotosm.test
+    depends_on:
+      hanko-db:
+        condition: service_healthy
+      hanko-migrate:
+        condition: service_completed_successfully
+    profiles:
+      - dev
+
+  hanko-db:
+    image: postgres:17-alpine
+    container_name: portal-hanko-db
+    environment:
+      - POSTGRES_USER=hanko
+      - POSTGRES_PASSWORD=hanko
+      - POSTGRES_DB=hanko
+    volumes:
+      - hanko_db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U hanko -d hanko"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    profiles:
+      - dev
+
+  # Mailhog - catches emails sent by Hanko (password recovery, verification) in dev
+  mailhog:
+    image: mailhog/mailhog:latest
+    container_name: portal-mailhog
+    ports:
+      - "8025:8025"
+    profiles:
+      - dev
+
 volumes:
   postgres_data:
     name: portal-postgres-data
   minio_data:
     name: portal-minio-data
+  hanko_db_data:
+    name: portal-hanko-db-data


### PR DESCRIPTION
Adds a `make dev` path to run Portal + Login standalone with HTTPS, without depending on the external `hot-dev-env` repo or Traefik.

## Changes

- **`Makefile`**: new `certs` target (generates local HTTPS certs for `*.hotosm.test` via `mkcert`). `dev` now depends on `certs` and runs `docker compose --profile dev up` directly instead of delegating to `hot-dev-env`. Requires `../login` to be present (frontend + backend), fails fast with a clear error otherwise.
- **`Caddyfile`** (new): reverse proxy terminating HTTPS for `portal.hotosm.test` and `login.hotosm.test`, routing to the respective frontend/backend containers and to Hanko's public API/webauthn/passcode endpoints.
- **`config/hanko-config.yaml`** (new): dev configuration for the Hanko service (CORS for the two `.test` origins, session/cookie settings scoped to `.hotosm.test`, SMTP via `mailhog`, webauthn/passkey/passcode disabled for local dev).
- **`docker-compose.yml`**: adds `caddy`, `login-frontend`, `login-backend`, `hanko`, `hanko-migrate`, `hanko-db` services (all under the `dev` profile); points the portal backend/frontend at the new local HTTPS origins instead of `localhost`.

## Requirements to run locally

- [mkcert](https://github.com/FiloSottile/mkcert) installed
- `../login` present as a sibling repo (frontend + backend)
- `portal.hotosm.test` and `login.hotosm.test` resolving to `127.0.0.1` in `/etc/hosts`

## How to test

```
make dev
```
Then log in at `https://portal.hotosm.test` and confirm the Hanko login flow round-trips through `https://login.hotosm.test`.
