### PR TITLE
Feature: Add plan projects using OpenAerialMap TMS URLs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ target/
 .ipynb_checkpoints
 .python-version
 .uv/
+certs/
 
 # Node
 node_modules/

--- a/backend/app/api/routes/open_aerial_map/open_aerial_map.py
+++ b/backend/app/api/routes/open_aerial_map/open_aerial_map.py
@@ -33,7 +33,7 @@ _sync_task: Optional[asyncio.Task] = None
 # ── Background sync scheduler ─────────────────────────────────────────────────
 
 
-async def _db_sync_scheduler() -> None:
+async def db_sync_scheduler() -> None:
     """Background task: sync OAM data from API into DB every week."""
     from app.core.database import AsyncSessionLocal
 
@@ -51,7 +51,7 @@ def start_sync_scheduler() -> None:
     """Start the weekly OAM → DB background sync task."""
     global _sync_task
     if _sync_task is None or _sync_task.done():
-        _sync_task = asyncio.create_task(_db_sync_scheduler())
+        _sync_task = asyncio.create_task(db_sync_scheduler())
         logger.info("OAM DB sync scheduler started (weekly updates)")
 
 

--- a/backend/app/services/open_aerial_map_service.py
+++ b/backend/app/services/open_aerial_map_service.py
@@ -1,13 +1,174 @@
 """OpenAerialMap service: reusable fetch-by-id with caching (API fallback)."""
 
+import asyncio
+import logging
+
 import httpx
 
 from app.core.cache import DEFAULT_TTL, get_cached, set_cached
 from app.services.exceptions import UpstreamUnavailable
 
+logger = logging.getLogger(__name__)
+
 # Always use the public OAM API for individual image lookups (plan hydration,
 # URL resolution). settings.oam_api_url is for the local STAC sync (oam_service.py).
 _OAM_PUBLIC_API = "https://api.openaerialmap.org"
+
+
+_META_PAGE_SIZE = 2000
+_META_MAX_PAGES = 15  # covers ~30k images — headroom above OAM's current ~21k catalog
+_META_PAGE_BATCH = 5  # pages fetched concurrently per round (OAM's /meta is slow: ~3-11s/page)
+_META_SEARCH_TIMEOUT = 20.0  # overall budget for the whole paginated search
+_META_PAGE_CACHE_PREFIX = "oam_meta_page_"
+
+# Marks a project_id produced by url_resolver for a TMS tile URL (see
+# find_image_by_tms_ids) — its two ids are S3 object-path segments, not OAM's
+# _id/user_id, so they need the uuid-substring search instead of /meta/{id}.
+TMS_ID_PREFIX = "tms:"
+
+
+def is_tms_project_id(project_id: str) -> bool:
+    return project_id.startswith(TMS_ID_PREFIX)
+
+
+def parse_tms_project_id(project_id: str) -> tuple[str, str]:
+    """Split a "tms:{id1}:{id2}" project_id into its two ids."""
+    id1, id2 = project_id[len(TMS_ID_PREFIX) :].split(":", 1)
+    return id1, id2
+
+# Keep strong references to fire-and-forget warm-up tasks — otherwise asyncio
+# may garbage-collect them mid-flight since nothing else holds them.
+_background_tasks: set[asyncio.Task] = set()
+
+
+def schedule_tms_warmup(image_id: str) -> None:
+    """Run a TMS uuid search in the background without making the caller wait.
+
+    Finding a TMS-sourced image (image_id starting with "tms:") requires paging
+    through OAM's /meta catalog — too slow to block "add project to plan" on
+    (see find_image_by_tms_ids). This kicks off that same search detached from
+    the request, purely to warm its page cache, so that the next call to
+    fetch_imagery_by_id for this image_id (e.g. on plan hydration, which is
+    time-bounded) is likely to find the answer already cached instead of
+    repeating the full search.
+    """
+    task = asyncio.ensure_future(fetch_imagery_by_id(image_id))
+    _background_tasks.add(task)
+
+    def _on_done(t: asyncio.Task) -> None:
+        _background_tasks.discard(t)
+        if not t.cancelled() and t.exception() is not None:
+            logger.warning("OAM TMS cache warm-up failed for %s: %s", image_id, t.exception())
+
+    task.add_done_callback(_on_done)
+
+
+async def _fetch_meta_page(client: httpx.AsyncClient, page: int) -> list[dict]:
+    cache_key = f"{_META_PAGE_CACHE_PREFIX}{page}"
+    images = get_cached(cache_key)
+    if images is not None:
+        return images
+    params = {"limit": _META_PAGE_SIZE, "page": page, "sort": "desc"}
+    response = await client.get(f"{_OAM_PUBLIC_API}/meta", params=params)
+    response.raise_for_status()
+    images = response.json().get("results") or []
+    set_cached(cache_key, images, DEFAULT_TTL)
+    return images
+
+
+def _filter_oam_result(result: dict) -> dict:
+    """Keep only the fields callers of fetch_imagery_by_id actually use."""
+    return {
+        "title": result.get("title"),
+        "thumbnail": (result.get("properties") or {}).get("thumbnail"),
+        "bbox": result.get("bbox"),
+    }
+
+
+def _match_in_page(images: list[dict], needle: str) -> dict | None:
+    result = next((img for img in images if needle in (img.get("uuid") or "")), None)
+    return None if result is None else _filter_oam_result(result)
+
+
+async def _run_batch(
+    client: httpx.AsyncClient, pages: list[int], needle: str
+) -> tuple[dict | None, bool]:
+    """Fetch `pages` concurrently, returning as soon as any of them matches.
+
+    Uses as_completed (not gather) so one slow straggler in the batch can't hold
+    up a match that already arrived from a faster sibling — the still-pending
+    fetches are cancelled instead of waited on. Returns (match, reached_last_page).
+    """
+    tasks = [asyncio.ensure_future(_fetch_meta_page(client, p)) for p in pages]
+    reached_last_page = False
+    try:
+        for coro in asyncio.as_completed(tasks):
+            images = await coro
+            match = _match_in_page(images, needle)
+            if match is not None:
+                return match, reached_last_page
+            if len(images) < _META_PAGE_SIZE:
+                reached_last_page = True
+    finally:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+    return None, reached_last_page
+
+
+async def _search_tms_pages(needle: str) -> dict | None:
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        # Fast path: check page 1 alone first — most TMS lookups are for recently
+        # uploaded images, which land on the newest (first) page. Avoids firing a
+        # full concurrent batch at OAM when a single request would have been enough.
+        page1 = await _fetch_meta_page(client, 1)
+        match = _match_in_page(page1, needle)
+        if match is not None:
+            return match
+        if len(page1) < _META_PAGE_SIZE:
+            return None  # page 1 was also the last page
+
+        page = 2
+        while page <= _META_MAX_PAGES:
+            batch_pages = list(range(page, min(page + _META_PAGE_BATCH, _META_MAX_PAGES + 1)))
+            match, reached_last_page = await _run_batch(client, batch_pages, needle)
+            if match is not None:
+                return match
+            if reached_last_page:
+                break
+            page += len(batch_pages)
+
+    return None
+
+
+async def find_image_by_tms_ids(id1: str, id2: str) -> dict | None:
+    """Resolve an OAM image from the two ids in a TMS tile URL.
+
+    The tiles.openaerialmap.org/{id1}/0/{id2}/{z}/{x}/{y} URL does not carry OAM's
+    own _id or user_id — id1/id2 are S3 object-path segments (the image's `uuid`
+    field is "https://.../{id1}/0/{id2}.tif"). There is no direct /meta/{id} lookup
+    for these, so this pages through /meta (newest first) searching for a uuid
+    containing both segments, stopping at the first match or the last page.
+
+    OAM's /meta endpoint is slow and variable (measured ~3-11s per 2000-item page,
+    occasionally more), so pages are fetched _META_PAGE_BATCH at a time
+    (concurrently) rather than one by one, returning as soon as any page in the
+    batch matches instead of waiting on the slowest one. The whole search is
+    capped at _META_SEARCH_TIMEOUT — a slow/unresponsive OAM is reported as
+    UpstreamUnavailable rather than silently hanging or being misreported as
+    "not found".
+
+    Deliberately independent of the oam_images DB table/sync scheduler (that table
+    backs an unused map feature and may be removed). Each page is cached separately
+    so repeated lookups — even for different images — reuse pages already fetched.
+    """
+    needle = f"/{id1}/0/{id2}"
+    try:
+        return await asyncio.wait_for(_search_tms_pages(needle), timeout=_META_SEARCH_TIMEOUT)
+    except asyncio.TimeoutError as e:
+        raise UpstreamUnavailable("open-aerial-map: TMS search timed out") from e
+    except (httpx.RequestError, httpx.HTTPStatusError) as e:
+        raise UpstreamUnavailable(f"open-aerial-map: {e}") from e
 
 
 async def fetch_imagery_by_id(
@@ -25,7 +186,15 @@ async def fetch_imagery_by_id(
     image_id may be a compound "{user_id}:{image_id}" (produced by url_resolver for
     /user/ URLs). The user_id is preserved here to resolve file-UUID-based IDs (see
     OAM bug comment below); only image_id is used in the primary /meta/{id} call.
+
+    image_id may also be "tms:{id1}:{id2}" (produced by url_resolver for TMS tile
+    URLs), resolved via find_image_by_tms_ids instead — those ids are not
+    valid /meta/{id} lookups at all (see that function's docstring).
     """
+    if is_tms_project_id(image_id):
+        id1, id2 = parse_tms_project_id(image_id)
+        return await find_image_by_tms_ids(id1, id2)
+
     user_id: str | None = None
     if ":" in image_id:
         user_id, image_id = image_id.split(":", 1)

--- a/backend/app/services/plans_service.py
+++ b/backend/app/services/plans_service.py
@@ -484,6 +484,27 @@ async def hydrate_one(
             featured=row.featured, data=row.data, upstream=upstream, error=None if upstream else "not_found",
         )
 
+    if row.app == "open-aerial-map" and open_aerial_map_service.is_tms_project_id(row.project_id):
+        # TMS-sourced OAM projects resolve via a slow catalog search (see
+        # open_aerial_map_service.find_image_by_tms_ids) that manages its own
+        # ~20s budget internally — the generic HYDRATE_FETCHER_TIMEOUT (8s) would
+        # almost always cut it off before it can finish. A timeout/failure here
+        # means "still searching", not "broken", so it maps to error="pending"
+        # (spinner) rather than upstream_timeout/upstream_unavailable (which the
+        # UI shows as a permanent "Unavailable" state) — the next hydration
+        # retries and benefits from whatever pages are already cached.
+        try:
+            upstream = await open_aerial_map_service.fetch_imagery_by_id(
+                row.project_id, force_refresh=force_refresh
+            )
+        except Exception:
+            upstream = None
+        return HydratedProjectItem(
+            app=row.app, project_id=row.project_id, status=row.status,
+            featured=row.featured, data=row.data, upstream=upstream,
+            error=None if upstream else "pending",
+        )
+
     fetcher = APP_FETCHERS.get(row.app)
     if fetcher is None:
         return HydratedProjectItem(
@@ -817,5 +838,16 @@ async def resolve_project_url(
         base = f"{p.scheme}://{p.netloc}"
         upstream = await field_tm_service.fetch_project_by_id(project_id, base_url=base)
         return UrlResolveResponse(app=app, project_id=project_id, upstream=upstream)
+
+    if app == "open-aerial-map" and open_aerial_map_service.is_tms_project_id(project_id):
+        # TMS tile URLs don't carry OAM's _id, so verifying/titling them means
+        # paging through OAM's whole /meta catalog (no indexed lookup by uuid
+        # exists) — measured up to ~20s. Don't block adding the project on that;
+        # accept it immediately and let the title fill in on a later plan
+        # hydration, while warming its page cache in the background so that
+        # hydration is likely to find it already cached instead of repeating
+        # the same slow search.
+        open_aerial_map_service.schedule_tms_warmup(project_id)
+        return UrlResolveResponse(app=app, project_id=project_id, upstream=None)
 
     return await _fetch_by_app_project(app, project_id, hanko_cookie=hanko_cookie)

--- a/backend/app/services/url_resolver.py
+++ b/backend/app/services/url_resolver.py
@@ -3,25 +3,33 @@
 import re
 
 from app.models.plan import AppLiteral
+from app.services.open_aerial_map_service import TMS_ID_PREFIX
 
-_PATTERNS: list[tuple[re.Pattern[str], AppLiteral]] = [
-    (re.compile(r"https?://tasks\.hotosm\.org/projects/(\d+)", re.I), "tasking-manager"),
+_PATTERNS: list[tuple[re.Pattern[str], AppLiteral, str]] = [
+    (re.compile(r"https?://tasks\.hotosm\.org/projects/(\d+)", re.I), "tasking-manager", ""),
     # Drone TM project IDs can be numeric or slug-based (e.g. "bo-phase-3")
-    (re.compile(r"https?://drone\.hotosm\.org/projects/([^/\s?#]+)", re.I), "drone-tasking-manager"),
-    (re.compile(r"https?://(?:field\.hotosm\.org|field\.hotosm\.test|fieldtm\.testlogin\.hotosm\.org)/projects/(\d+)", re.I), "field-tm"),
-    (re.compile(r"https?://fair\.hotosm\.org/ai-models/(\d+)", re.I), "fair"),
+    (re.compile(r"https?://drone\.hotosm\.org/projects/([^/\s?#]+)", re.I), "drone-tasking-manager", ""),
+    (re.compile(r"https?://(?:field\.hotosm\.org|field\.hotosm\.test|fieldtm\.testlogin\.hotosm\.org)/projects/(\d+)", re.I), "field-tm", ""),
+    (re.compile(r"https?://fair\.hotosm\.org/ai-models/(\d+)", re.I), "fair", ""),
     # Export Tool: optional locale (e.g. /en/) and optional /v3/ path segments.
-    (re.compile(r"https?://export\.hotosm\.org/(?:[a-z]{2}/)?(?:v3/)?exports/([0-9a-f\-]{8,})", re.I), "export-tool"),
+    (re.compile(r"https?://export\.hotosm\.org/(?:[a-z]{2}/)?(?:v3/)?exports/([0-9a-f\-]{8,})", re.I), "export-tool", ""),
     # OAM: https://map.openaerialmap.org/#/{coords}/latest/{hex-id}[?...]
-    (re.compile(r"https?://map\.openaerialmap\.org/#/[^/]+/latest/([0-9a-f]+)", re.I), "open-aerial-map"),
+    (re.compile(r"https?://map\.openaerialmap\.org/#/[^/]+/latest/([0-9a-f]+)", re.I), "open-aerial-map", ""),
     # OAM: /#/{coords}/user/{user-id}/{hex-id}[.ext][?...] (logged-in user view)
     # project_id encoded as "{user_id}:{image_id}" to preserve the user path segment.
     # The image ID sometimes carries a file extension (e.g. .tif) that is stripped.
-    (re.compile(r"https?://map\.openaerialmap\.org/#/[^/]+/user/([0-9a-f]+)/([0-9a-f]+)(?:\.[a-z]+)?", re.I), "open-aerial-map"),
+    (re.compile(r"https?://map\.openaerialmap\.org/#/[^/]+/user/([0-9a-f]+)/([0-9a-f]+)(?:\.[a-z]+)?", re.I), "open-aerial-map", ""),
+    # OAM TMS tile URL ("TMS" button on an image page) — stable format, unlike the
+    # map.openaerialmap.org viewer URL above which has changed more than once.
+    # The two ids are S3 object-path segments, NOT OAM's _id/user_id, so they can't
+    # be used with GET /meta/{id} directly. Prefixed with "tms:" so
+    # open_aerial_map_service.fetch_imagery_by_id knows to resolve them via a
+    # uuid-substring search instead of a direct /meta/{id} lookup.
+    (re.compile(r"https?://tiles\.openaerialmap\.org/([0-9a-f]{24})/\d+/([0-9a-f]{24})", re.I), "open-aerial-map", TMS_ID_PREFIX),
     # uMap: https://umap.hotosm.org/{locale}/map/{slug}_{id}[#...]
-    (re.compile(r"https?://umap\.hotosm\.org/[a-z]{2,5}/map/[^#/]+_(\d+)", re.I), "umap"),
+    (re.compile(r"https?://umap\.hotosm\.org/[a-z]{2,5}/map/[^#/]+_(\d+)", re.I), "umap", ""),
     # ChatMap: https://chatmap.hotosm.org/#map/{uuid}
-    (re.compile(r"https?://chatmap\.hotosm\.org/#map/([0-9a-f-]+)", re.I), "chatmap"),
+    (re.compile(r"https?://chatmap\.hotosm\.org/#map/([0-9a-f-]+)", re.I), "chatmap", ""),
 ]
 
 
@@ -38,9 +46,9 @@ def parse_project_url(url: str) -> tuple[AppLiteral, str] | None:
     if url and not re.match(r"https?://", url, re.I):
         url = f"https://{url}"
 
-    for pattern, app in _PATTERNS:
+    for pattern, app, id_prefix in _PATTERNS:
         m = pattern.match(url)
         if m:
             project_id = ":".join(m.groups()) if len(m.groups()) > 1 else m.group(1)
-            return app, project_id
+            return app, f"{id_prefix}{project_id}"
     return None

--- a/backend/app/tests/api/open_aerial_map/test_open_aerial_map_service.py
+++ b/backend/app/tests/api/open_aerial_map/test_open_aerial_map_service.py
@@ -1,0 +1,207 @@
+# portal/backend/app/tests/api/open_aerial_map/test_open_aerial_map_service.py
+
+"""Tests for app/services/open_aerial_map_service.py — TMS tile URL resolution."""
+
+import asyncio
+
+import pytest
+import respx
+from httpx import Response
+
+from app.core.cache import clear_cache
+from app.services import open_aerial_map_service
+from app.services.exceptions import UpstreamUnavailable
+
+_OAM_API = "https://api.openaerialmap.org"
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_cache()
+    yield
+    clear_cache()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_imagery_by_id_tms_match():
+    """A 'tms:{id1}:{id2}' id resolves via uuid-substring search, not /meta/{id}."""
+    mock_response = {
+        "meta": {"found": 1},
+        "results": [
+            {
+                "_id": "691e75d9628460062aec9418",
+                "uuid": "https://oin-hotosm-temp.s3.amazonaws.com/691e7375628460062aec8bca/0/691e7375628460062aec8bcb.tif",
+                "title": "Spanish EMT Falmouth",
+                "bbox": [-77.66, 18.49, -77.65, 18.49],
+                "properties": {"thumbnail": "https://example.com/thumb.png"},
+            }
+        ],
+    }
+    route = respx.get(f"{_OAM_API}/meta").mock(return_value=Response(200, json=mock_response))
+
+    result = await open_aerial_map_service.fetch_imagery_by_id(
+        "tms:691e7375628460062aec8bca:691e7375628460062aec8bcb"
+    )
+
+    assert result == {
+        "title": "Spanish EMT Falmouth",
+        "thumbnail": "https://example.com/thumb.png",
+        "bbox": [-77.66, 18.49, -77.65, 18.49],
+    }
+    assert route.called
+    request = route.calls.last.request
+    params = dict(request.url.params)
+    assert params["limit"] == "2000"
+    assert params["page"] == "1"
+    # Fast path: a match on page 1 alone shouldn't trigger any further fetches.
+    assert route.call_count == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_imagery_by_id_tms_no_match():
+    """No match, and page 1 is smaller than the page size -> None after a single call."""
+    mock_response = {"meta": {"found": 1}, "results": [{"_id": "abc", "uuid": "https://x/other/0/ids.tif"}]}
+    route = respx.get(f"{_OAM_API}/meta").mock(return_value=Response(200, json=mock_response))
+
+    result = await open_aerial_map_service.fetch_imagery_by_id("tms:aaaa:bbbb")
+
+    assert result is None
+    assert route.call_count == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_imagery_by_id_tms_paginates_until_match(monkeypatch):
+    """A match past page 1 is found by paging (one page per round here) past full pages."""
+    monkeypatch.setattr(open_aerial_map_service, "_META_PAGE_SIZE", 1)
+    monkeypatch.setattr(open_aerial_map_service, "_META_PAGE_BATCH", 1)
+    page1 = {"meta": {"found": 2}, "results": [{"_id": "1", "uuid": "https://x/other/0/other.tif"}]}
+    page2 = {
+        "meta": {"found": 2},
+        "results": [{"_id": "2", "uuid": "https://x/id1/0/id2.tif", "title": "On page 2"}],
+    }
+    route = respx.get(f"{_OAM_API}/meta").mock(
+        side_effect=[Response(200, json=page1), Response(200, json=page2)]
+    )
+
+    result = await open_aerial_map_service.fetch_imagery_by_id("tms:id1:id2")
+
+    assert result == {"title": "On page 2", "thumbnail": None, "bbox": None}
+    assert route.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_run_batch_returns_as_soon_as_match_found(monkeypatch):
+    """A match on a fast page returns without waiting for a slower sibling.
+
+    Regression test: asyncio.gather() would block on the slowest page in the
+    batch even after a faster sibling already had the match, so one straggler
+    page could drag a real, fast match out past the overall search timeout.
+    """
+    monkeypatch.setattr(open_aerial_map_service, "_META_PAGE_SIZE", 1)
+
+    async def fake_fetch(client, page):
+        if page == 3:
+            await asyncio.sleep(0.05)
+            return [{"_id": "3", "uuid": "https://x/id1/0/id2.tif", "title": "Fast match"}]
+        await asyncio.sleep(5)  # slow straggler with no match — must not be waited on
+        return [{"_id": str(page), "uuid": f"https://x/o{page}/0/o{page}.tif"}]
+
+    monkeypatch.setattr(open_aerial_map_service, "_fetch_meta_page", fake_fetch)
+
+    loop = asyncio.get_event_loop()
+    t0 = loop.time()
+    match, reached_last_page = await open_aerial_map_service._run_batch(
+        None, [2, 3, 4], "/id1/0/id2"
+    )
+    elapsed = loop.time() - t0
+
+    assert match == {"title": "Fast match", "thumbnail": None, "bbox": None}
+    assert elapsed < 1, f"waited {elapsed:.1f}s — should have returned as soon as page 3 matched"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_imagery_by_id_tms_batches_pages_concurrently(monkeypatch):
+    """Past page 1, pages are fetched _META_PAGE_BATCH at a time in one round."""
+    monkeypatch.setattr(open_aerial_map_service, "_META_PAGE_SIZE", 1)
+    monkeypatch.setattr(open_aerial_map_service, "_META_PAGE_BATCH", 5)
+    monkeypatch.setattr(open_aerial_map_service, "_META_MAX_PAGES", 6)
+    page1 = {"meta": {"found": 6}, "results": [{"_id": "1", "uuid": "https://x/other/0/other.tif"}]}
+
+    def other(n: int) -> dict:
+        return {"meta": {"found": 6}, "results": [{"_id": str(n), "uuid": f"https://x/o{n}/0/o{n}.tif"}]}
+
+    page4 = {
+        "meta": {"found": 6},
+        "results": [{"_id": "4", "uuid": "https://x/id1/0/id2.tif", "title": "On page 4"}],
+    }
+    # page 1 (fast path, no match) then the batch for pages 2-6, in order.
+    responses = [Response(200, json=page1)] + [
+        Response(200, json=(page4 if p == 4 else other(p))) for p in range(2, 7)
+    ]
+    route = respx.get(f"{_OAM_API}/meta").mock(side_effect=responses)
+
+    result = await open_aerial_map_service.fetch_imagery_by_id("tms:id1:id2")
+
+    assert result == {"title": "On page 4", "thumbnail": None, "bbox": None}
+    # page 1 + the full batch of pages 2-6, even though the match was on page 4 —
+    # the batch is fetched concurrently before any of it is inspected.
+    assert route.call_count == 6
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_imagery_by_id_tms_stops_at_max_pages(monkeypatch):
+    """When every page is full and nothing matches, the search stops at the page cap."""
+    monkeypatch.setattr(open_aerial_map_service, "_META_PAGE_SIZE", 1)
+    monkeypatch.setattr(open_aerial_map_service, "_META_MAX_PAGES", 3)
+    full_page = {"meta": {"found": 100}, "results": [{"_id": "x", "uuid": "https://x/other/0/other.tif"}]}
+    route = respx.get(f"{_OAM_API}/meta").mock(return_value=Response(200, json=full_page))
+
+    result = await open_aerial_map_service.fetch_imagery_by_id("tms:id1:id2")
+
+    assert result is None
+    # page 1 (fast path) + batch covering pages 2-3 (capped by _META_MAX_PAGES).
+    assert route.call_count == 3
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_imagery_by_id_tms_search_timeout(monkeypatch):
+    """A slow OAM is reported as UpstreamUnavailable, not a false 'not found'."""
+    monkeypatch.setattr(open_aerial_map_service, "_META_SEARCH_TIMEOUT", 0.01)
+
+    async def _slow_page(client, page):
+        await asyncio.sleep(1)
+        return []
+
+    monkeypatch.setattr(open_aerial_map_service, "_fetch_meta_page", _slow_page)
+
+    with pytest.raises(UpstreamUnavailable):
+        await open_aerial_map_service.fetch_imagery_by_id("tms:id1:id2")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_imagery_by_id_tms_uses_cache():
+    """A second lookup within the TTL window does not re-hit the OAM API."""
+    mock_response = {
+        "meta": {"found": 1},
+        "results": [
+            {
+                "_id": "1",
+                "uuid": "https://x/id1/0/id2.tif",
+                "title": "Cached image",
+            }
+        ],
+    }
+    route = respx.get(f"{_OAM_API}/meta").mock(return_value=Response(200, json=mock_response))
+
+    first = await open_aerial_map_service.fetch_imagery_by_id("tms:id1:id2")
+    second = await open_aerial_map_service.fetch_imagery_by_id("tms:id1:id2")
+
+    assert first == second == {"title": "Cached image", "thumbnail": None, "bbox": None}
+    assert route.call_count == 1

--- a/backend/app/tests/test_plans.py
+++ b/backend/app/tests/test_plans.py
@@ -389,6 +389,63 @@ async def test_hydrate_plan_upstream_unavailable(auth_client):
 
 
 @pytest.mark.asyncio
+async def test_hydrate_plan_oam_tms_still_resolving_shows_pending_not_unavailable(auth_client):
+    """A TMS-sourced OAM project that hasn't resolved yet is "pending", not
+
+    "upstream_unavailable"/"upstream_timeout" — those map to a permanent
+    "Unavailable" badge in the UI, which is wrong for something that just
+    hasn't finished its (up to ~20s) catalog search yet.
+    """
+    client, _ = auth_client
+    resp = await client.post(
+        "/api/plans",
+        json={
+            "name": "P",
+            "projects": [{"app": "open-aerial-map", "project_id": "tms:aaa:bbb"}],
+        },
+    )
+    plan_id = resp.json()["id"]
+
+    with patch.object(
+        plans_service.open_aerial_map_service,
+        "fetch_imagery_by_id",
+        AsyncMock(side_effect=UpstreamUnavailable("TMS search timed out")),
+    ):
+        resp = await client.get(f"/api/plans/{plan_id}?refresh=true")
+
+    assert resp.status_code == 200
+    project = resp.json()["projects"][0]
+    assert project["error"] == "pending"
+    assert project["upstream"] is None
+
+
+@pytest.mark.asyncio
+async def test_hydrate_plan_oam_tms_resolves_once_found(auth_client):
+    """Once the search finds the image, it hydrates normally (error=None)."""
+    client, _ = auth_client
+    resp = await client.post(
+        "/api/plans",
+        json={
+            "name": "P",
+            "projects": [{"app": "open-aerial-map", "project_id": "tms:aaa:bbb"}],
+        },
+    )
+    plan_id = resp.json()["id"]
+
+    with patch.object(
+        plans_service.open_aerial_map_service,
+        "fetch_imagery_by_id",
+        AsyncMock(return_value={"title": "Found it", "bbox": None, "thumbnail": None}),
+    ):
+        resp = await client.get(f"/api/plans/{plan_id}?refresh=true")
+
+    assert resp.status_code == 200
+    project = resp.json()["projects"][0]
+    assert project["error"] is None
+    assert project["upstream"]["title"] == "Found it"
+
+
+@pytest.mark.asyncio
 async def test_orphan_end_to_end_flow(auth_client):
     client, _ = auth_client
     resp = await client.post(

--- a/backend/app/tests/test_resolve_project_url.py
+++ b/backend/app/tests/test_resolve_project_url.py
@@ -1,0 +1,43 @@
+# portal/backend/app/tests/test_resolve_project_url.py
+
+"""Tests for plans_service.resolve_project_url — OAM TMS fast-path (issue #none)."""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.services import plans_service
+
+
+@pytest.mark.asyncio
+async def test_resolve_oam_tms_url_returns_immediately():
+    """A TMS tile URL resolves without waiting on OAM's slow catalog search.
+
+    Adding a project shouldn't block on the up-to-20s uuid search needed to
+    find a TMS URL's title (see open_aerial_map_service.find_image_by_tms_ids).
+    upstream is None immediately; the title fills in on a later plan hydration.
+    """
+    url = (
+        "https://tiles.openaerialmap.org/6a029b68ef395bce007be43a/0/"
+        "6a029b68ef395bce007be43b/{z}/{x}/{y}"
+    )
+    with patch.object(plans_service.open_aerial_map_service, "schedule_tms_warmup") as warmup:
+        result = await plans_service.resolve_project_url(url)
+
+    assert result.app == "open-aerial-map"
+    assert result.project_id == "tms:6a029b68ef395bce007be43a:6a029b68ef395bce007be43b"
+    assert result.upstream is None
+    warmup.assert_called_once_with(result.project_id)
+
+
+@pytest.mark.asyncio
+async def test_resolve_oam_tms_url_skips_the_live_verification_path():
+    """The generic upstream-verification path is never reached for a TMS id."""
+    url = "https://tiles.openaerialmap.org/6a029b68ef395bce007be43a/0/6a029b68ef395bce007be43b/{z}/{x}/{y}"
+    with (
+        patch.object(plans_service.open_aerial_map_service, "schedule_tms_warmup"),
+        patch.object(plans_service, "_fetch_by_app_project") as fetch_by_app_project,
+    ):
+        await plans_service.resolve_project_url(url)
+
+    fetch_by_app_project.assert_not_called()

--- a/backend/app/tests/test_url_resolver.py
+++ b/backend/app/tests/test_url_resolver.py
@@ -76,6 +76,24 @@ from app.services.url_resolver import parse_project_url
             "open-aerial-map",
             "aabbccddeeff00112233aabb:112233aabbccddeeff001122",
         ),
+        # OAM TMS tile URL ("TMS" button on an image page)
+        (
+            "https://tiles.openaerialmap.org/6a029b68ef395bce007be43a/0/6a029b68ef395bce007be43b/{z}/{x}/{y}",
+            "open-aerial-map",
+            "tms:6a029b68ef395bce007be43a:6a029b68ef395bce007be43b",
+        ),
+        # same, with a file extension on the tile suffix
+        (
+            "http://tiles.openaerialmap.org/573a17d4cd0663bb003c32b6/0/575fcf142b67227a79b4fbfd/{z}/{x}/{y}.png",
+            "open-aerial-map",
+            "tms:573a17d4cd0663bb003c32b6:575fcf142b67227a79b4fbfd",
+        ),
+        # pasted without a scheme
+        (
+            "tiles.openaerialmap.org/691e7375628460062aec8bca/0/691e7375628460062aec8bcb/{z}/{x}/{y}",
+            "open-aerial-map",
+            "tms:691e7375628460062aec8bca:691e7375628460062aec8bcb",
+        ),
         # --- umap ---
         (
             "https://umap.hotosm.org/es/map/test-portal_2675#16/-34.572928/-58.430572",
@@ -122,6 +140,8 @@ def test_valid_urls(url: str, expected_app: str, expected_id: str) -> None:
         "https://map.openaerialmap.org/#/0,0,3/abc123",
         # OAM /user/ path but non-hex user id
         "https://map.openaerialmap.org/#/0,0,3/user/not-a-hex-id/6a04633ecc972f0164bdda20",
+        # OAM TMS URL with a short (non-24-char) id — not a valid ObjectId pair
+        "https://tiles.openaerialmap.org/abc123/0/def456/{z}/{x}/{y}",
         # umap missing _{id}
         "https://umap.hotosm.org/es/map/no-number-here",
         # chatmap missing uuid

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -170,6 +170,7 @@
   "plan_picker_url_not_found": "Project not found. Check the URL.",
   "plan_picker_url_service_unavailable": "Could not reach the service. Try again later.",
   "plan_picker_url_not_recognized": "URL not recognized.",
+  "plan_picker_url_oam_tms_pending": "OpenAerialMap image (resolving name…)",
   "plan_card_projects_singular": "project",
   "plan_card_projects_plural": "projects",
   "plan_toast_create_error": "Failed to create plan",
@@ -191,6 +192,7 @@
   "plan_refreshing_button": "Updating…",
   "plan_project_missing_badge": "Not found",
   "plan_project_unavailable_badge": "Unavailable",
+  "plan_project_pending_badge": "Resolving…",
   "plan_project_missing_label": "This project no longer exists in the source app.",
   "plan_project_remove_button": "Remove from plan"
 }

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -170,6 +170,7 @@
   "plan_picker_url_not_found": "Proyecto no encontrado. Verifica la URL.",
   "plan_picker_url_service_unavailable": "No se pudo conectar con el servicio. Inténtalo más tarde.",
   "plan_picker_url_not_recognized": "URL no reconocida.",
+  "plan_picker_url_oam_tms_pending": "Imagen de OpenAerialMap (resolviendo nombre…)",
   "plan_card_projects_singular": "proyecto",
   "plan_card_projects_plural": "proyectos",
   "plan_toast_create_error": "Error al crear el plan",
@@ -191,6 +192,7 @@
   "plan_refreshing_button": "Actualizando…",
   "plan_project_missing_badge": "No encontrado",
   "plan_project_unavailable_badge": "No disponible",
+  "plan_project_pending_badge": "Resolviendo…",
   "plan_project_missing_label": "Este proyecto ya no existe en la app de origen.",
   "plan_project_remove_button": "Quitar del plan"
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -170,6 +170,7 @@
   "plan_picker_url_not_found": "Projet introuvable. Vérifiez l'URL.",
   "plan_picker_url_service_unavailable": "Impossible de joindre le service. Réessayez plus tard.",
   "plan_picker_url_not_recognized": "URL non reconnue.",
+  "plan_picker_url_oam_tms_pending": "Image OpenAerialMap (résolution du nom…)",
   "plan_card_projects_singular": "projet",
   "plan_card_projects_plural": "projets",
   "plan_toast_create_error": "Échec de la création du plan",
@@ -191,6 +192,7 @@
   "plan_refreshing_button": "Mise à jour…",
   "plan_project_missing_badge": "Introuvable",
   "plan_project_unavailable_badge": "Indisponible",
+  "plan_project_pending_badge": "Résolution…",
   "plan_project_missing_label": "Ce projet n'existe plus dans l'application source.",
   "plan_project_remove_button": "Retirer du plan"
 }

--- a/frontend/src/components/shared/Spinner.tsx
+++ b/frontend/src/components/shared/Spinner.tsx
@@ -1,0 +1,33 @@
+interface SpinnerProps {
+  size?: "sm" | "md";
+  color?: "brand" | "white";
+  label?: string;
+  className?: string;
+}
+
+const SIZE_CLASSES: Record<NonNullable<SpinnerProps["size"]>, string> = {
+  sm: "h-3 w-3 border-2",
+  md: "h-4 w-4 border-2",
+};
+
+const COLOR_CLASSES: Record<NonNullable<SpinnerProps["color"]>, string> = {
+  brand: "border-hot-gray-300 border-t-hot-red",
+  white: "border-white/40 border-t-white",
+};
+
+function Spinner({
+  size = "sm",
+  color = "brand",
+  label,
+  className = "",
+}: SpinnerProps) {
+  return (
+    <span
+      className={`inline-block animate-spin rounded-full ${SIZE_CLASSES[size]} ${COLOR_CLASSES[color]} ${className}`}
+      role="status"
+      aria-label={label}
+    />
+  );
+}
+
+export default Spinner;

--- a/frontend/src/portal-plans/MyPlanPage.tsx
+++ b/frontend/src/portal-plans/MyPlanPage.tsx
@@ -118,6 +118,25 @@ function MyPlanPage() {
     revalidatedRef.current = planId;
     refreshPlan();
   }, [plan, planId, refreshPlan]);
+
+  // Some projects (e.g. an OAM TMS URL, whose title needs a slow catalog search
+  // — see find_image_by_tms_ids) can still be "pending" after that one refresh.
+  // Keep retrying every few seconds, bounded, until nothing is pending anymore —
+  // a single attempt isn't reliable enough for something that routinely takes
+  // 10-20s and shares the plan's connection with everyone else's slow requests.
+  const pendingRetriesRef = useRef(0);
+  useEffect(() => {
+    if (!plan || !planId) return;
+    const hasPending = plan.projects.some((p) => p.error === "pending");
+    if (!hasPending) {
+      pendingRetriesRef.current = 0;
+      return;
+    }
+    if (pendingRetriesRef.current >= 6) return;
+    pendingRetriesRef.current += 1;
+    const timer = setTimeout(() => refreshPlan(), 5000);
+    return () => clearTimeout(timer);
+  }, [plan, planId, refreshPlan]);
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
   );
@@ -200,9 +219,13 @@ function MyPlanPage() {
         project_exists: true,
         // Fall back to the picker option's title so the card shows a name right
         // away; some apps only expose the title (no upstream) until rehydration.
+        // Skip that fallback while still resolving (e.g. an OAM TMS URL) — its
+        // "title" is just the raw project_id placeholder, not a real name, and
+        // stashing it in `data` would mark the row as already hydrated, hiding
+        // the pending spinner and never getting replaced by the real title.
         data:
           (opt?.upstream as Record<string, unknown> | null) ??
-          (opt?.title ? { name: opt.title } : null),
+          (opt?.title && !opt?.isResolving ? { name: opt.title } : null),
       });
     }
     // Append newly created tasks.

--- a/frontend/src/portal-plans/components/AppSourceSection.tsx
+++ b/frontend/src/portal-plans/components/AppSourceSection.tsx
@@ -1,4 +1,5 @@
 import Checkbox from "../../components/shared/Checkbox";
+import Spinner from "../../components/shared/Spinner";
 import { m } from "../../paraglide/messages";
 import { projectKey } from "../../utils/utils";
 import type {
@@ -124,7 +125,14 @@ export function AppSourceSection({
                   defaultChecked={isChecked}
                   onChange={() => toggle(key)}
                 >
-                  {p.title}
+                  {p.isResolving ? (
+                    <span className="inline-flex items-center gap-xs">
+                      <Spinner label={m.plan_picker_url_oam_tms_pending()} />
+                      {source.label}
+                    </span>
+                  ) : (
+                    p.title
+                  )}
                 </Checkbox>
               );
             })}

--- a/frontend/src/portal-plans/components/PlanProjectCard.tsx
+++ b/frontend/src/portal-plans/components/PlanProjectCard.tsx
@@ -3,6 +3,7 @@ import placeholder from "../../assets/images/placeholder.png";
 import Dropdown from "../../components/shared/Dropdown";
 import ProjectDialog from "./ProjectDialog";
 import DropdownItem from "../../components/shared/DropdownItem";
+import Spinner from "../../components/shared/Spinner";
 import Tag from "../../components/shared/Tag";
 import { APP_META } from "../../utils/appMeta";
 import {
@@ -175,6 +176,9 @@ function PlanProjectCard({
     project.project_exists &&
     (project.error === "upstream_unavailable" ||
       project.error === "upstream_timeout");
+  // Still being resolved (e.g. an OAM TMS URL's slow catalog search) — not
+  // broken, just not done yet. A later refresh will fill in the real title.
+  const pending = project.project_exists && project.error === "pending";
 
   useEffect(() => {
     setLocalStatus(project.status);
@@ -210,6 +214,12 @@ function PlanProjectCard({
         {unavailable && (
           <span className="absolute bottom-1 left-1 z-10 bg-hot-gray-600 text-white text-xs font-medium px-2 py-0.5 rounded">
             {m.plan_project_unavailable_badge()}
+          </span>
+        )}
+        {pending && (
+          <span className="absolute bottom-1 left-1 z-10 flex items-center gap-xs bg-hot-gray-600 text-white text-xs font-medium px-2 py-0.5 rounded">
+            <Spinner color="white" />
+            {m.plan_project_pending_badge()}
           </span>
         )}
         {!project.project_exists ? null : onStatusChange ? (
@@ -269,9 +279,11 @@ function PlanProjectCard({
           ) : (
             <>
               <span className="block w-full text-left whitespace-normal text-base font-bold">
-                <span className="line-clamp-2">{title}</span>
+                <span className="line-clamp-2">
+                  {pending ? meta.name : title}
+                </span>
               </span>
-              {unavailable && onDelete && (
+              {(unavailable || pending) && onDelete && (
                 <button
                   type="button"
                   onClick={(e) => {
@@ -299,7 +311,7 @@ function PlanProjectCard({
 
   return (
     <>
-      {project.project_exists && !unavailable && (
+      {project.project_exists && !unavailable && !pending && (
         <ProjectDialog
           open={dialogOpen}
           onClose={() => setDialogOpen(false)}
@@ -328,6 +340,12 @@ function PlanProjectCard({
         // Upstream can't be reached: keep the card grayed out and non-openable
         // (no dialog), but leave it interactive so it can still be removed.
         <div className={`${cardClassName} grayscale opacity-60`} aria-disabled="true">
+          {cardContent}
+        </div>
+      ) : pending ? (
+        // Still resolving (not broken) — no dialog yet since there's nothing to
+        // show, but keep the normal look (no grayscale) so it doesn't read as an error.
+        <div className={cardClassName} aria-busy="true">
           {cardContent}
         </div>
       ) : (

--- a/frontend/src/portal-plans/hooks/useAddProjectByUrl.ts
+++ b/frontend/src/portal-plans/hooks/useAddProjectByUrl.ts
@@ -51,6 +51,10 @@ export function useAddProjectByUrl() {
       }
 
       const upstream = resolvedUpstream ?? {};
+      const isPendingOamTms =
+        result.app === "open-aerial-map" &&
+        result.project_id.startsWith("tms:") &&
+        !resolvedUpstream;
       const title =
         (upstream.name as string | undefined) ??
         (upstream.title as string | undefined) ??
@@ -62,6 +66,7 @@ export function useAddProjectByUrl() {
           project_id: result.project_id,
           title,
           upstream: resolvedUpstream,
+          isResolving: isPendingOamTms,
         },
         key,
       );

--- a/frontend/src/portal-plans/types.ts
+++ b/frontend/src/portal-plans/types.ts
@@ -88,6 +88,7 @@ export interface ProjectOption {
   project_id: string
   title: string
   upstream?: Record<string, unknown> | null
+  isResolving?: boolean
 }
 
 export interface ProjectSource {


### PR DESCRIPTION
Adds support for OpenAerialMap's TMS tile URL format (the "TMS" button on an image's detail page), alongside the already-supported map.openaerialmap.org format. Example: https://tiles.openaerialmap.org/{id1}/0/{id2}/{z}/{x}/{y}.

**Why the first load of an OAM URL takes ~13s**
The TMS URL doesn't carry OAM's real _id or any directly queryable identifier — the two ids in the path are S3 object-path segments (uuid), not the catalog's primary key. OAM's public API has no endpoint to search by that field, so the only way to resolve a title is to page through the entire catalog (GET /meta) looking for those ids inside each image's uuid.

Each page of that API is inherently slow (measured 3-11s per page, sometimes more), so if the image isn't on the most recent page, the search can take 10-20s. Once found, the page it was found on gets cached (5 minutes), so subsequent searches for nearby images are instant — hence "the first time is slow, after that it's fast."

To keep that delay from blocking the "add project" action: the project is added to the Plan immediately (without waiting on the search), the search runs in the background, and while unresolved a spinner ("Resolving…") is shown instead of incorrect data or an error.