### PR TITLE
Feature: Admin permissions to access the test page

### DIFF
--- a/backend/app/api/routes/test.py
+++ b/backend/app/api/routes/test.py
@@ -7,24 +7,27 @@ These endpoints demonstrate the hotosm-auth integration:
 
 from fastapi import APIRouter
 
-from hotosm_auth_fastapi import CurrentUser, OSMConnectionRequired
+from hotosm_auth_fastapi import AdminUser, OSMConnectionRequired
 from app.schemas.auth import UserInfoResponse, OSMInfoResponse
 
 router = APIRouter()
 
 
 @router.get("/me", response_model=UserInfoResponse)
-async def test_user_auth(user: CurrentUser) -> UserInfoResponse:
+async def test_user_auth(user: AdminUser) -> UserInfoResponse:
     """
-    Test endpoint requiring Hanko authentication.
+    Test endpoint requiring Hanko authentication and admin access.
 
     Returns authenticated user information from JWT.
 
-    **Authentication**: Requires valid Hanko session (JWT in cookie or Bearer token)
+    **Authentication**:
+    - Requires valid Hanko session (JWT in cookie or Bearer token)
+    - Requires the user's email to be in ADMIN_EMAILS
 
     **Returns**:
     - 200: User information
     - 401: Not authenticated
+    - 403: Not an admin
 
     **Example**:
     ```bash
@@ -42,22 +45,23 @@ async def test_user_auth(user: CurrentUser) -> UserInfoResponse:
 
 @router.get("/osm", response_model=OSMInfoResponse)
 async def test_osm_auth(
-    user: CurrentUser,
+    user: AdminUser,
     osm: OSMConnectionRequired,
 ) -> OSMInfoResponse:
     """
-    Test endpoint requiring both Hanko authentication and OSM connection.
+    Test endpoint requiring Hanko authentication, admin access, and OSM connection.
 
     Returns OSM connection information from encrypted cookie.
 
     **Authentication**:
     - Requires valid Hanko session (JWT in cookie or Bearer token)
+    - Requires the user's email to be in ADMIN_EMAILS
     - Requires OSM connection (encrypted cookie from OAuth flow)
 
     **Returns**:
     - 200: OSM connection information
     - 401: Not authenticated (no valid Hanko session)
-    - 403: OSM connection required (logged in but not connected to OSM)
+    - 403: Not an admin, or OSM connection required (logged in but not connected to OSM)
 
     **Example**:
     ```bash

--- a/frontend/src/pages/ForbiddenPage.tsx
+++ b/frontend/src/pages/ForbiddenPage.tsx
@@ -1,0 +1,28 @@
+import { useNavigate } from "react-router-dom";
+import Button from "../components/shared/Button";
+import PageWrapper from "../components/shared/PageWrapper";
+import { useLanguage } from "../contexts/LanguageContext";
+
+function ForbiddenPage() {
+  const navigate = useNavigate();
+  const { currentLanguage } = useLanguage();
+
+  return (
+    <PageWrapper>
+      <div className="flex flex-col items-center justify-center gap-md py-xl text-center">
+        <p className="text-8xl font-bold text-hot-gray-200">403</p>
+        <div className="flex flex-col gap-xs">
+          <p className="text-2xl font-bold text-hot-gray-950">Access denied</p>
+          <p className="text-hot-gray-600">
+            You don't have permission to view this page.
+          </p>
+        </div>
+        <Button onClick={() => navigate(`/${currentLanguage}`)}>
+          Go to home
+        </Button>
+      </div>
+    </PageWrapper>
+  );
+}
+
+export default ForbiddenPage;

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "../contexts/AuthContext";
 import HomePage from "../pages/HomePage";
 import WelcomePage from "../pages/WelcomePage";
@@ -10,6 +11,7 @@ import DataPage from "../portal-data/DataPage";
 import HelpPage from "../pages/HelpPage";
 import TestPage from "../pages/TestPage";
 import NotFoundPage from "../pages/NotFoundPage";
+import ForbiddenPage from "../pages/ForbiddenPage";
 import PlanPage from "../portal-plans/PlanPage";
 import AddPlanPage from "../portal-plans/AddPlanPage";
 import EditPlanPage from "../portal-plans/EditPlanPage";
@@ -26,6 +28,40 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
 
   if (!isLogin) {
     return <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
+}
+
+// Component to handle routes restricted to admin users.
+// Admin status is verified against the backend (/api/test/me, gated by
+// ADMIN_EMAILS via AdminUser) rather than trusted client-side.
+function AdminRoute({ children }: { children: React.ReactNode }) {
+  const { isLogin, isAuthLoading } = useAuth();
+
+  const { isLoading: isAdminCheckLoading, isError: isNotAdmin } = useQuery({
+    queryKey: ["admin-check"],
+    queryFn: async () => {
+      const response = await fetch("/api/test/me", { credentials: "include" });
+      if (!response.ok) {
+        throw new Error(String(response.status));
+      }
+      return response.json();
+    },
+    enabled: isLogin,
+    retry: false,
+  });
+
+  if (isAuthLoading || (isLogin && isAdminCheckLoading)) {
+    return null;
+  }
+
+  if (!isLogin) {
+    return <Navigate to="/" replace />;
+  }
+
+  if (isNotAdmin) {
+    return <ForbiddenPage />;
   }
 
   return <>{children}</>;
@@ -84,9 +120,9 @@ export function AppRoutes() {
       <Route
         path="/:locale/test"
         element={
-          <ProtectedRoute>
+          <AdminRoute>
             <TestPage />
-          </ProtectedRoute>
+          </AdminRoute>
         }
       />
       <Route path="/:locale/plan">


### PR DESCRIPTION
The debug page `/test` (which exposes auth test endpoints and project data) was accessible to any logged-in user. This change restricts it to admin users only, on both frontend and backend, and adds a 403 error page for users without permission.

## Changes

**Backend** — `backend/app/api/routes/test.py`
- The `/me` and `/osm` endpoints now require `AdminUser` (previously `CurrentUser`), using the existing `require_admin` mechanism from `hotosm_auth_fastapi`, which validates the user's email against the `ADMIN_EMAILS` whitelist.
- Automatically returns 403 for any authenticated user whose email isn't in `ADMIN_EMAILS`. This is the real source of truth: even if the API is called directly (bypassing the frontend), it stays blocked.

**Frontend** — `frontend/src/routes/index.tsx`, `frontend/src/pages/ForbiddenPage.tsx`
- New `AdminRoute` component that, in addition to checking login state, queries `/api/test/me` to confirm the user is an admin before rendering `TestPage`.
- The `/:locale/test` route now uses `AdminRoute` instead of `ProtectedRoute`.
- New `ForbiddenPage.tsx` (403 / Access denied), same visual pattern as `NotFoundPage.tsx`. Shown when a logged-in non-admin user tries to access `/test`.

**No CORS changes**: this restriction is role-based authorization, not cross-origin — `CORSMiddleware`/`allow_origins` are untouched.

## Environment / deploy requirements

`ADMIN_EMAILS` (comma-separated list of emails) was already consumed by `require_admin`, but until now it didn't gate any portal endpoint — this PR is its first real consumer. Needs to be set up/confirmed in each environment:

- **Local (`hot-dev-env`)**: add to `hot-dev-env/.env` (not `portal/.env` — that file isn't used by the `hot-dev-env` stack):
  ```
  ADMIN_EMAILS=admin@hotosm.org,<other-local-admin-emails>
  ```
  Then recreate the container: `docker compose up -d --force-recreate portal-backend` (a plain restart won't apply the new value, since docker-compose's `${ADMIN_EMAILS}` interpolation is resolved at container creation time).

- **Staging and production (GitHub Actions)**: confirm the `ADMIN_EMAILS` secret is configured in the repo with the real admin emails for each environment. It's already referenced in `deploy-testing.yml` and `deploy-production.yml` (`secrets.ADMIN_EMAILS`), but if the secret was never set with real values, those environments will have no effective admin until it's added.

## Test plan

- Backend: `curl` to `/api/test/me` with a non-admin user's cookie → 403. With an `ADMIN_EMAILS`-listed user's cookie → 200.
- Frontend: non-admin logged-in user visiting `/test` → sees `ForbiddenPage` (403). Admin user → sees `TestPage` normally. Logged-out user → still redirects to home (unchanged).
- `pnpm test` (frontend) and `pytest` (backend) with no regressions.
