### PR TITLE
Enable groups feature flag on dev deployment

### DIFF
--- a/compose.test.yaml
+++ b/compose.test.yaml
@@ -50,6 +50,7 @@ services:
       - DEBUG=false
       - HANKO_API_URL=https://dev.login.hotosm.org
       - JWT_ISSUER=auto
+      - LOGIN_GROUPS_ENABLED=true
       - COOKIE_SECRET=${COOKIE_SECRET}
       - COOKIE_DOMAIN=.hotosm.org
       - OSM_CLIENT_ID=${OSM_CLIENT_ID}


### PR DESCRIPTION
Turns on `LOGIN_GROUPS_ENABLED` for the dev.portal backend so plan team/org scopes resolve against dev.login.

- Single line in `compose.test.yaml` (dev-only compose; production uses a separate compose, so it stays off in prod).
- Backend already points `HANKO_API_URL` at `dev.login.hotosm.org`, which routes `/api/groups` to the login backend, so no extra URL config is needed.
- With the flag on, the Manage Permissions dialog and group-based view/edit access work end to end.