### PR TITLE
Enable groups feature flag in production

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -159,6 +159,7 @@ jobs:
           OSM_REDIRECT_URI=${{ secrets.OSM_REDIRECT_URI }}
           ADMIN_EMAILS=${{ secrets.ADMIN_EMAILS }}
           HANKO_API_URL=https://login.hotosm.org
+          LOGIN_GROUPS_ENABLED=true
           DRONE_TM_BACKEND_URL=https://drone.hotosm.org/api
           FAIR_API_BASE_URL=https://api-prod.fair.hotosm.org/api/v1
           UMAP_BASE_URL=https://umap.hotosm.org

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       DEBUG: ${DEBUG:-false}
       # Authentication settings
       HANKO_API_URL: ${HANKO_API_URL:-https://dev.login.hotosm.org}
+      # Team/organization plan scopes; login exposes GET /api/groups since 0.4.0
+      LOGIN_GROUPS_ENABLED: ${LOGIN_GROUPS_ENABLED:-false}
       JWT_ISSUER: ${JWT_ISSUER:-auto}
       COOKIE_SECRET: ${COOKIE_SECRET}
       COOKIE_DOMAIN: ${COOKIE_DOMAIN:-}


### PR DESCRIPTION
Plans only offer "Personal" in the permissions dialog, even for team owners.

The backend gates team/organization scopes behind `LOGIN_GROUPS_ENABLED`, which
was off because login did not expose `GET /api/groups` yet. Login 0.4.0 went out
today and does expose it, so the flag can be turned on.

The compose lists env vars one by one, so the flag has to be declared there as
well, not only in the .env the deploy generates. `LOGIN_API_URL` is not needed:
it falls back to `HANKO_API_URL`, already set to https://login.hotosm.org.